### PR TITLE
GH-6 Loosen restrictions on gems

### DIFF
--- a/fluent-plugin-papertrail.gemspec
+++ b/fluent-plugin-papertrail.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", "~> 0.10.45"
-  spec.add_dependency "fluent-mixin-config-placeholders", "~> 0.2.0"
+  spec.add_dependency "fluentd", '>= 0.10', '< 2'
+  spec.add_dependency "fluent-mixin-config-placeholders", "~> 0.4.0"
   spec.add_dependency "syslog_protocol"
 
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
This loosens the restrictions on dependency gems to resolve issues
with newer Ruby and older versions of fluentd gem. Fixes #6

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>